### PR TITLE
#23 Fix: Adjusted Expertise List Letter Spacing

### DIFF
--- a/components/sections/Expertise/index.jsx
+++ b/components/sections/Expertise/index.jsx
@@ -12,7 +12,7 @@ const Expertise = () => {
             {areasOfExpertise.map((area, index) => (
               <li
                 key={index}
-                className="text-xl md:text-2xl w-290 md:w-310 -leading-tighter border-b border-primaryGray-50"
+                className="text-xl border-b -tracking-wider sm:-tracking-tighter md:text-2xl w-290 md:w-310 border-primaryGray-50"
               >
                 {area}
               </li>


### PR DESCRIPTION
### Task Description _(❗️Required)_

Adjusted the expertise list items' letter spacing on mobile,iPad, tablet, and desktop screens.
### Type of Task

- [x] fix
- [ ] chore
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] docs

### Guidelines

- [x] Does your code follow ES6+ syntax?
- [x] Did you use arrow functional components?
- [x] Did you thoroughly review your code?
- [x] Have you checked if your code does not introduce conflicts in the main codebase?


### Screenshots

### Ticket Link _(❗️Required)_
https://www.notion.so/apeunit/Expertise-section-all-spacing-tracking-between-text-ce9e970d568d4e2d8ff14c90ea74b6fd
