### PR TITLE
#19 Fix: Add Gap for Mobile Gap

### DIFF
--- a/components/Layout/Header.jsx
+++ b/components/Layout/Header.jsx
@@ -4,13 +4,13 @@ import LinkItem from "../ui/LinkItem";
 const Header = () => {
   return (
     <Wrapper>
-      <div className="flex flex-col justify-between gap-5 pt-6.5 sm:pt-12 text-xl lg:flex-row sm:text-2xl -tracking-tighter sm:tracking-normal">
+      <div className="flex flex-col justify-between gap-4.2 sm:gap-5.5 pt-6.5 sm:pt-12 text-xl lg:flex-row sm:text-2xl -tracking-tighter sm:tracking-normal">
         <h1>Ape Unit</h1>
         <div className="max-w-189.25 xl:max-w-201.5 md:pt-0">
           Unit➇ is a pioneering technology company specialing in decentralised
           technologies that creates end-to-end digital experiences for protocols
           including
-          <span className="text-purple px-1">
+          <span className="px-1 text-purple">
             Ethereum, Tezos, Near, Algorand, Celo
           </span>
           and more. Its team of 2,500+ digital specialists across 30+ locations

--- a/components/Layout/Header.jsx
+++ b/components/Layout/Header.jsx
@@ -4,7 +4,7 @@ import LinkItem from "../ui/LinkItem";
 const Header = () => {
   return (
     <Wrapper>
-      <div className="flex flex-col justify-between gap-4.2 sm:gap-5.5 pt-6.5 sm:pt-12 text-xl lg:flex-row sm:text-2xl -tracking-tighter sm:tracking-normal">
+      <div className="flex flex-col justify-between pt-6.5 sm:pt-12 text-xl lg:flex-row sm:text-2xl -tracking-tighter sm:tracking-normal gap-4.2 sm:gap-5.5 ">
         <h1>Ape Unit</h1>
         <div className="max-w-189.25 xl:max-w-201.5 md:pt-0">
           Unit➇ is a pioneering technology company specialing in decentralised


### PR DESCRIPTION
### Task Description _(❗️Required)_

Add a gap between the heading and the content for mobile devices.

### Type of Task

- [x] fix
- [ ] chore
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] docs

### Guidelines

- [x] Does your code follow ES6+ syntax?
- [x] Did you use arrow functional components?
- [x] Did you thoroughly review your code?
- [x] Have you checked if your code does not introduce conflicts in the main codebase?


### Screenshots

### Ticket Link _(❗️Required)_

https://www.notion.so/apeunit/header-section-iPad-mobile-content-gap-b6a8d2dc636b4451b61cf7e3e244a7e8